### PR TITLE
fix: cpu_exclusive_scan

### DIFF
--- a/scan/main.cpp
+++ b/scan/main.cpp
@@ -30,12 +30,14 @@ void cpu_exclusive_scan(int* start, int* end, int* output) {
     // note to students: this C code can be helpful when debugging the
     // output of intermediate steps of your CUDA segmented scan.
     // Uncomment the line above to use it as a reference.
+    // before using this C code, make sure your N is power of 2
+    // or it will out-of-bounds access during downsweep phase.
   
     int N = end - start;
     memmove(output, start, N*sizeof(int));
     
     // upsweep phase
-    for (int twod = 1; twod < N/2; twod*=2) {
+    for (int twod = 1; twod <= N/2; twod*=2) {
         int twod1 = twod*2;
 	
         for (int i = 0; i < N; i += twod1) {


### PR DESCRIPTION
Firstly, the result after upsweep phase goes wrong. (although not influence the final result)
My experiment result is below.
```bash
(two_d < N / 2)
    ./cudaScan -i ones -n 7
    Array size: 7
    1 2 1 4 1 2 1 (upsweep phase)
    2 3 4 6 3 4 3 (downsweep phase)

    ./cudaScan -i ones -n 8
    Array size: 8
    1 2 1 4 1 2 1 4 (upsweep phase)
    0 1 2 3 4 5 6 7 (downsweep phase)

(two_d <= N / 2)
    ./cudaScan -i ones -n 7
    Array size: 7
    1 2 1 4 1 2 1 (upsweep phase)
    2 3 4 6 3 4 3 (downsweep phase)

    ./cudaScan -i ones -n 8
    Array size: 8
    1 2 1 4 1 2 1 8 (upsweep phase)
    0 1 2 3 4 5 6 7 (downsweep phase)
```
Secondly, as N is not given as power of 2, so during the downsweep, it always visit out-of-bound in `output[i + twod1 - 1]`.

If you want to totally fix it, only choose to transfer N by function like `nextPow2` at very first, or just mention at comments, "use it, only when N is power of 2!"